### PR TITLE
Fix createClass deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Title from './title.jsx';
 
-let HelloMessage = React.createClass({
+class HelloMessage extends React.Component {
   render() {
     return (
       <div>
@@ -27,6 +27,6 @@ let HelloMessage = React.createClass({
       </div>
     );
   }
-});
+};
 
 ReactDOM.render(<HelloMessage greeting="Welcome to your first StealJS and React app!" />, document.getElementById('app'));


### PR DESCRIPTION
Accessing createClass via the main React package is deprecated, so this uses a plain JavaScript class instead.